### PR TITLE
feat: add uvx remote execution support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "unsplash-mcp-server"
 version = "0.1.0"
-description = "Add your description here"
+description = "MCP server for searching Unsplash photos"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -9,3 +9,6 @@ dependencies = [
     "httpx>=0.26.0",
     "python-dotenv>=1.1.0",
 ]
+
+[project.scripts]
+unsplash-mcp-server = "server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ dependencies = [
 
 [project.scripts]
 unsplash-mcp-server = "server:main"
+
+[tool.setuptools]
+py-modules = ["server"]

--- a/server.py
+++ b/server.py
@@ -112,3 +112,12 @@ async def search_photos(
     except Exception as e:
         print(f"Request error: {str(e)}")
         raise
+
+
+def main():
+    """Entry point for uvx remote execution."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -116,6 +116,15 @@ async def search_photos(
 
 def main():
     """Entry point for uvx remote execution."""
+    import sys
+    import io
+
+    # Ensure UTF-8 encoding for stdout/stderr
+    if sys.stdout.encoding != 'utf-8':
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+    if sys.stderr.encoding != 'utf-8':
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
     mcp.run()
 
 


### PR DESCRIPTION
## Summary
- Add `main()` entry point function in `server.py` for CLI execution
- Add `[project.scripts]` entry point in `pyproject.toml`
- Add `[tool.setuptools]` config to properly package the server module
- Update project description

## Usage

After this change, users can run the MCP server directly via uvx:

```bash
uvx --from git+https://github.com/hellokaton/unsplash-mcp-server unsplash-mcp-server
```

Or configure in editors (Cursor/Claude Desktop):

```json
{
  "mcpServers": {
    "unsplash": {
      "command": "uvx",
      "args": ["--from", "git+https://github.com/hellokaton/unsplash-mcp-server", "unsplash-mcp-server"],
      "env": {
        "UNSPLASH_ACCESS_KEY": "your_api_key"
      }
    }
  }
}
```

## Test plan
- [x] Tested `uvx --from git+https://github.com/6Kmfi6HP/unsplash-mcp-server unsplash-mcp-server` - runs successfully