### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,8 @@ Add the following configuration to your Cursor editor's `settings.json`:
 
 - [Twitter/X](https://x.com/hellokaton)
 - [GitHub Issues](https://github.com/hellokaton/unsplash-mcp-server/issues)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hellokaton-unsplash-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hellokaton-unsplash-mcp-server)